### PR TITLE
Updates to support windows store test projects

### DIFF
--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/ConfigurationErrorsException.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/ConfigurationErrorsException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Net;
+using System.Runtime.Serialization;
+
+
+namespace System.Configuration
+{
+    public class ConfigurationErrorsException : Exception
+    {
+        public ConfigurationErrorsException()
+        {
+        }
+
+        public ConfigurationErrorsException(string message) : base(message)
+        {
+        }
+
+        public ConfigurationErrorsException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/Console.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/Console.cs
@@ -1,0 +1,13 @@
+﻿
+namespace System
+{
+    using System.Diagnostics;
+
+    public class Console
+    {
+        public static void WriteLine(string message)
+        {
+            Debug.WriteLine(message);
+        }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/CultureInfoHelper.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/CultureInfoHelper.cs
@@ -1,0 +1,13 @@
+﻿
+namespace TechTalk.SpecFlow.Compatibility
+{
+    using System.Globalization;
+
+    internal static class CultureInfoHelper
+    {
+        public static CultureInfo GetCultureInfo(string cultureName)
+        {
+            return new CultureInfo(cultureName);
+        }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/DescriptionAttribute.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/DescriptionAttribute.cs
@@ -1,0 +1,15 @@
+﻿
+namespace System.ComponentModel
+{
+    using System;
+
+    public class DescriptionAttribute : Attribute
+    {
+        public DescriptionAttribute(string description)
+        {
+            Description = description;
+        }
+
+        public string Description { get; private set; }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/EnumHelper.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/EnumHelper.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace TechTalk.SpecFlow.Compatibility
+{
+    internal static class EnumHelper
+    {
+        public static Array GetValues(Type enumType)
+        {
+            if (!enumType.GetTypeInfo().IsEnum)
+            {
+                throw new ArgumentException("Type '" + enumType.Name + "' is not an enum");
+            }
+
+            var values = new List<object>();
+
+            var fields = from field in enumType.GetTypeInfo().DeclaredFields
+                         where field.IsLiteral
+                         select field;
+
+            foreach (FieldInfo field in fields)
+            {
+                object value = field.GetValue(enumType);
+                values.Add(value);
+            }
+
+            return values.ToArray();
+        }
+
+        public static string[] GetNames(Type enumType)
+        {
+            if (!enumType.GetTypeInfo().IsEnum)
+            {
+                throw new ArgumentException("Type '" + enumType.Name + "' is not an enum");
+            }
+
+            var fiArray = enumType.GetTypeInfo().DeclaredFields.Where(f => f.IsPublic && f.IsStatic);
+            return fiArray.Select(fi => fi.Name).ToArray();
+        }
+    }
+
+    internal static class TypeHelper
+    {
+        public static bool IsNested(Type type)
+        {
+            return type.DeclaringType != null;
+        }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/ExceptionHelper.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/ExceptionHelper.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System
+{
+    using System.Reflection;
+
+    internal static class ExceptionHelper
+    {
+        public static Exception PreserveStackTrace(this Exception ex, string methodInfo = null)
+        {
+            return ex;
+        }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/MissingMethodException.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/MissingMethodException.cs
@@ -1,0 +1,11 @@
+﻿
+namespace System
+{
+    public class MissingMethodException : Exception
+    {
+        public MissingMethodException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/StringExtensions.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/StringExtensions.cs
@@ -1,0 +1,11 @@
+﻿
+namespace System
+{
+    public static class StringExtensions
+    {
+        public static bool Contains(this string self, char c)
+        {
+            return self.Contains(c.ToString());
+        }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/ConfigDefaults.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/ConfigDefaults.cs
@@ -1,0 +1,23 @@
+using TechTalk.SpecFlow.BindingSkeletons;
+
+namespace TechTalk.SpecFlow.Configuration
+{
+    public static class ConfigDefaults
+    {
+        internal const string FeatureLanguage = "en-US";
+        internal const string ToolLanguage = "";
+
+        internal const string UnitTestProviderName = "MSTest.winrt";
+
+        internal const bool DetectAmbiguousMatches = true;
+        internal const bool StopAtFirstError = false;
+        internal const MissingOrPendingStepsOutcome MissingOrPendingStepsOutcome = TechTalk.SpecFlow.Configuration.MissingOrPendingStepsOutcome.Inconclusive;
+
+        internal const bool TraceSuccessfulSteps = true;
+        internal const bool TraceTimings = false;
+        internal const string MinTracedDuration = "0:0:0.1";
+        internal const StepDefinitionSkeletonStyle StepDefinitionSkeletonStyle = TechTalk.SpecFlow.BindingSkeletons.StepDefinitionSkeletonStyle.RegexAttribute;
+
+        internal const bool AllowDebugGeneratedFiles = false;
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/EnumerableExtensions.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/EnumerableExtensions.cs
@@ -1,0 +1,16 @@
+﻿
+namespace System
+{
+    using System.Collections.Generic;
+
+    public static class EnumerableExtensions
+    {
+        public static void ForEach<T>(this List<T> self, Action<T> action)
+        {
+            foreach (var item in self)
+            {
+                action(item);
+            }
+        }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/RuntimeConfiguration.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/RuntimeConfiguration.cs
@@ -1,0 +1,188 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using BoDi;
+using TechTalk.SpecFlow.BindingSkeletons;
+using TechTalk.SpecFlow.Compatibility;
+using TechTalk.SpecFlow.Infrastructure;
+
+namespace TechTalk.SpecFlow.Configuration
+{
+    public class RuntimeConfiguration
+    {
+        //// public ContainerRegistrationCollection CustomDependencies { get; set; }
+
+        //language settings
+        public CultureInfo FeatureLanguage { get; set; }
+        public CultureInfo ToolLanguage { get; set; }
+        public CultureInfo BindingCulture { get; set; }
+
+        //unit test framework settings
+        public string RuntimeUnitTestProvider { get; set; }
+
+        //runtime settings
+        public bool DetectAmbiguousMatches { get; set; }
+        public bool StopAtFirstError { get; set; }
+        public MissingOrPendingStepsOutcome MissingOrPendingStepsOutcome { get; set; }
+
+        //tracing settings
+        public bool TraceSuccessfulSteps { get; set; }
+        public bool TraceTimings { get; set; }
+        public TimeSpan MinTracedDuration { get; set; }
+        public StepDefinitionSkeletonStyle StepDefinitionSkeletonStyle { get; set; }
+
+        public List<string> AdditionalStepAssemblies { get; private set; }
+
+        public RuntimeConfiguration()
+        {
+            FeatureLanguage = CultureInfoHelper.GetCultureInfo(ConfigDefaults.FeatureLanguage);
+            ToolLanguage = CultureInfoHelper.GetCultureInfo(ConfigDefaults.FeatureLanguage);
+            BindingCulture = null;
+
+            RuntimeUnitTestProvider = ConfigDefaults.UnitTestProviderName;
+
+            DetectAmbiguousMatches = ConfigDefaults.DetectAmbiguousMatches;
+            StopAtFirstError = ConfigDefaults.StopAtFirstError;
+            MissingOrPendingStepsOutcome = ConfigDefaults.MissingOrPendingStepsOutcome;
+
+            TraceSuccessfulSteps = ConfigDefaults.TraceSuccessfulSteps;
+            TraceTimings = ConfigDefaults.TraceTimings;
+            MinTracedDuration = TimeSpan.Parse(ConfigDefaults.MinTracedDuration);
+            StepDefinitionSkeletonStyle = ConfigDefaults.StepDefinitionSkeletonStyle;
+
+            AdditionalStepAssemblies = new List<string>();
+        }
+
+        public static IEnumerable<PluginDescriptor> GetPlugins()
+        {
+            return Enumerable.Empty<PluginDescriptor>(); //TODO: support plugins in WindowsStore
+        }
+
+        public void LoadConfiguration()
+        {
+            /*
+            var section = (ConfigurationSectionHandler)ConfigurationManager.GetSection("specFlow");
+            if (section != null)
+                LoadConfiguration(section);
+
+            */
+        }
+
+        /*
+        private bool IsSpecified(ConfigurationElement configurationElement)
+        {
+            return configurationElement != null && configurationElement.ElementInformation.IsPresent;
+        }
+
+        public void LoadConfiguration(ConfigurationSectionHandler configSection)
+        {
+            if (configSection == null) throw new ArgumentNullException("configSection");
+
+            if (IsSpecified(configSection.Language))
+            {
+                FeatureLanguage = CultureInfo.GetCultureInfo(configSection.Language.Feature);
+                this.ToolLanguage = string.IsNullOrEmpty(configSection.Language.Tool) ?
+                    CultureInfo.GetCultureInfo(configSection.Language.Feature) :
+                    CultureInfo.GetCultureInfo(configSection.Language.Tool);
+            }
+
+            if (IsSpecified(configSection.BindingCulture))
+            {
+                this.BindingCulture = CultureInfo.GetCultureInfo(configSection.BindingCulture.Name);
+            }
+
+            if (IsSpecified(configSection.Runtime))
+            {
+                this.DetectAmbiguousMatches = configSection.Runtime.DetectAmbiguousMatches;
+                this.StopAtFirstError = configSection.Runtime.StopAtFirstError;
+                this.MissingOrPendingStepsOutcome = configSection.Runtime.MissingOrPendingStepsOutcome;
+
+                if (IsSpecified(configSection.Runtime.Dependencies))
+                {
+                    this.CustomDependencies = configSection.Runtime.Dependencies;
+                }
+            }
+
+            if (IsSpecified(configSection.UnitTestProvider))
+            {
+                if (!string.IsNullOrEmpty(configSection.UnitTestProvider.RuntimeProvider))
+                {
+                    //compatibility mode, we simulate a custom dependency
+                    this.RuntimeUnitTestProvider = "custom";
+                    AddCustomDependency(configSection.UnitTestProvider.RuntimeProvider, typeof(IUnitTestRuntimeProvider), this.RuntimeUnitTestProvider);
+                }
+                else
+                {
+                    this.RuntimeUnitTestProvider = configSection.UnitTestProvider.Name;
+                }
+            }
+
+            if (IsSpecified(configSection.Trace))
+            {
+                if (!string.IsNullOrEmpty(configSection.Trace.Listener)) // backwards compatibility
+                {
+                    AddCustomDependency(configSection.Trace.Listener, typeof(ITraceListener));
+                }
+
+                this.TraceSuccessfulSteps = configSection.Trace.TraceSuccessfulSteps;
+                this.TraceTimings = configSection.Trace.TraceTimings;
+                this.MinTracedDuration = configSection.Trace.MinTracedDuration;
+                this.StepDefinitionSkeletonStyle = configSection.Trace.StepDefinitionSkeletonStyle;
+            }
+
+            foreach (var element in configSection.StepAssemblies)
+            {
+                var assemblyName = ((StepAssemblyConfigElement)element).Assembly;
+                this.AdditionalStepAssemblies.Add(assemblyName);
+            }
+        }
+
+        private void AddCustomDependency(string implementationType, Type interfaceType, string name = null)
+        {
+            if (this.CustomDependencies == null)
+                this.CustomDependencies = new ContainerRegistrationCollection();
+
+            this.CustomDependencies.Add(implementationType, interfaceType.AssemblyQualifiedName, name);
+        }
+        */
+
+        #region Equality members
+
+        protected bool Equals(RuntimeConfiguration other)
+        {
+            return Equals(FeatureLanguage, other.FeatureLanguage) && Equals(ToolLanguage, other.ToolLanguage) && Equals(BindingCulture, other.BindingCulture) && string.Equals(RuntimeUnitTestProvider, other.RuntimeUnitTestProvider) && DetectAmbiguousMatches.Equals(other.DetectAmbiguousMatches) && StopAtFirstError.Equals(other.StopAtFirstError) && MissingOrPendingStepsOutcome.Equals(other.MissingOrPendingStepsOutcome) && TraceSuccessfulSteps.Equals(other.TraceSuccessfulSteps) && TraceTimings.Equals(other.TraceTimings) && MinTracedDuration.Equals(other.MinTracedDuration) && StepDefinitionSkeletonStyle.Equals(other.StepDefinitionSkeletonStyle) &&
+                (AdditionalStepAssemblies ?? new List<string>()).SequenceEqual(other.AdditionalStepAssemblies ?? new List<string>());
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((RuntimeConfiguration)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = (FeatureLanguage != null ? FeatureLanguage.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (ToolLanguage != null ? ToolLanguage.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (BindingCulture != null ? BindingCulture.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (RuntimeUnitTestProvider != null ? RuntimeUnitTestProvider.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ DetectAmbiguousMatches.GetHashCode();
+                hashCode = (hashCode * 397) ^ StopAtFirstError.GetHashCode();
+                hashCode = (hashCode * 397) ^ MissingOrPendingStepsOutcome.GetHashCode();
+                hashCode = (hashCode * 397) ^ TraceSuccessfulSteps.GetHashCode();
+                hashCode = (hashCode * 397) ^ TraceTimings.GetHashCode();
+                hashCode = (hashCode * 397) ^ MinTracedDuration.GetHashCode();
+                hashCode = (hashCode * 397) ^ StepDefinitionSkeletonStyle.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/ScenarioContextExtensions.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/ScenarioContextExtensions.cs
@@ -1,0 +1,17 @@
+namespace TechTalk.SpecFlow
+{
+    public static class ScenarioContextExtensions
+    {
+        private const string TestInstanceKey = "__TestInstance__";
+
+        public static void SetTestInstance(this ScenarioContext context, object testInstance)
+        {
+            context.Set(testInstance, TestInstanceKey);
+        }
+
+        public static T GetTestInstance<T>(this ScenarioContext context)
+        {
+            return (T)context.Get<object>(TestInstanceKey);
+        }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/TypeExtensions.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/TypeExtensions.cs
@@ -1,0 +1,60 @@
+﻿
+namespace System
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    public static class TypeExtensions
+    {
+        public static bool IsAssignableFrom(this Type self, Type baseType)
+        {
+            return self.GetTypeInfo().IsAssignableFrom(baseType.GetTypeInfo());
+        }
+
+        public static IEnumerable<PropertyInfo> GetProperties(this Type self)
+        {
+            return self.GetTypeInfo().DeclaredProperties;
+        }
+
+        public static IEnumerable<ConstructorInfo> GetConstructors(this Type self)
+        {
+            return self.GetTypeInfo().DeclaredConstructors;
+        }
+
+        public static IEnumerable<ConstructorInfo> GetPublicInstanceConstructors(this Type self)
+        {
+            return self.GetTypeInfo().DeclaredConstructors.Where(c => !c.IsStatic && c.IsPublic);
+        }
+
+        public static IEnumerable<ConstructorInfo> GetPrivateInstanceConstructors(this Type self)
+        {
+            return self.GetTypeInfo().DeclaredConstructors.Where(c => !c.IsStatic && !c.IsPublic);
+        }
+
+        public static Type[] GetGenericArguments(this Type type)
+        {
+            return type.GenericTypeArguments;
+        }
+
+        public static IEnumerable<Type> GetInterfaces(this Type self)
+        {
+            return self.GetTypeInfo().ImplementedInterfaces;
+        } 
+
+        public static bool IsInstanceOfType(this Type self, object other)
+        {
+            return other != null && other.GetType().IsAssignableFrom(self);
+        }
+
+        public static IEnumerable<Type> GetTypes(this Assembly assembly)
+        {
+            return assembly.DefinedTypes.Select(t => t.AsType());
+        }
+
+        public static IEnumerable<Attribute> GetCustomAttributes(this Type self, Type attributeType, bool inherit)
+        {
+            return self.GetTypeInfo().GetCustomAttributes(attributeType, inherit);
+        }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/UnitTestProviders.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/UnitTestProviders.cs
@@ -1,0 +1,14 @@
+﻿
+using BoDi;
+using TechTalk.SpecFlow.UnitTestProvider;
+
+namespace TechTalk.SpecFlow.Infrastructure
+{
+    partial class DefaultDependencyProvider
+    {
+        partial void RegisterUnitTestProviders(ObjectContainer container)
+        {
+            container.RegisterTypeAs<MsTestWinRTRuntimeProvider, IUnitTestRuntimeProvider>("mstest.winRT");
+        }
+    }
+}

--- a/AlternativeRuntimes/Runtime.WindowsStore/Properties/AssemblyInfo.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TechTalk.Specflow.WindowsStore")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/AlternativeRuntimes/Runtime.WindowsStore/TechTalk.Specflow.WindowsStore.csproj
+++ b/AlternativeRuntimes/Runtime.WindowsStore/TechTalk.Specflow.WindowsStore.csproj
@@ -1,0 +1,153 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TechTalk.Specflow.WindowsStore</RootNamespace>
+    <AssemblyName>TechTalk.Specflow.WindowsStore</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{BC8A1FFA-BEE3-4634-8014-F334798102B3};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NETFX_CORE,BODI_LIMITEDRUNTIME,WINRT</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE,BODI_LIMITEDRUNTIME,WINRT</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
+    <Folder Include="Async\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Runtime\**\*.cs" Exclude="..\..\Runtime\PlatformCompatibility\**;..\..\Runtime\PlatformSpecific\**;..\..\Runtime\Properties\**">
+      <Link>SharedRuntime\%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Include="..\..\lib\BoDi\BoDi.cs">
+      <Link>SharedRuntime\BoDi.cs</Link>
+    </Compile>
+    <Compile Include="..\..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="PlatformCompatibility\ConfigurationErrorsException.cs" />
+    <Compile Include="PlatformCompatibility\Console.cs" />
+    <Compile Include="PlatformCompatibility\CultureInfoHelper.cs" />
+    <Compile Include="PlatformCompatibility\DescriptionAttribute.cs" />
+    <Compile Include="PlatformCompatibility\EnumHelper.cs" />
+    <Compile Include="PlatformCompatibility\ExceptionHelper.cs" />
+    <Compile Include="PlatformCompatibility\MissingMethodException.cs" />
+    <Compile Include="PlatformCompatibility\StringExtensions.cs" />
+    <Compile Include="PlatformSpecific\ConfigDefaults.cs" />
+    <Compile Include="PlatformSpecific\EnumerableExtensions.cs" />
+    <Compile Include="PlatformSpecific\RuntimeConfiguration.cs" />
+    <Compile Include="PlatformSpecific\ScenarioContextExtensions.cs" />
+    <Compile Include="PlatformSpecific\TypeExtensions.cs" />
+    <Compile Include="PlatformSpecific\UnitTestProviders.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnitTestProvider\MsTestWinRTRuntimeProvider.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\Languages.xml">
+      <Link>Languages.xml</Link>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\Runtime\BindingSkeletons\DefaultSkeletonTemplates.sftemplate">
+      <Link>SharedRuntime\DefaultSkeletonTemplates.sftemplate</Link>
+    </EmbeddedResource>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '11.0' ">
+    <VisualStudioVersion>11.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/AlternativeRuntimes/Runtime.WindowsStore/UnitTestProvider/MsTestWinRTRuntimeProvider.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/UnitTestProvider/MsTestWinRTRuntimeProvider.cs
@@ -1,0 +1,121 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MsTestWinRTRuntimeProvider.cs" company="blinkBox Entertainment Ltd.">
+//   Copyright (c) blinkBox Entertainment Ltd. All rights reserved.
+// </copyright>
+// <summary>
+//   The ms test win rt runtime provider.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace TechTalk.SpecFlow.UnitTestProvider
+{
+    #region Using Directives
+
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+
+    using TechTalk.SpecFlow;
+
+    #endregion
+
+    /// <summary>
+    /// The ms test win rt runtime provider.
+    /// </summary>
+    internal class MsTestWinRTRuntimeProvider : IUnitTestRuntimeProvider
+    {
+        #region Constants
+
+        /// <summary>
+        /// The asser t_ type.
+        /// </summary>
+        private const string ASSERT_TYPE = "Microsoft.VisualStudio.TestPlatform.UnitTestFramework.Assert";
+
+        /// <summary>
+        /// The mstes t_ assembly.
+        /// </summary>
+        private const string MSTEST_ASSEMBLY = "Microsoft.VisualStudio.TestPlatform.UnitTestFramework, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
+
+        #endregion
+
+        #region Fields
+
+        /// <summary>
+        /// The assert inconclusive.
+        /// </summary>
+        private Action<string, object[]> assertInconclusive;
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// Gets the assembly name.
+        /// </summary>
+        public virtual string AssemblyName
+        {
+            get
+            {
+                return MSTEST_ASSEMBLY;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether delayed fixture tear down.
+        /// </summary>
+        public bool DelayedFixtureTearDown
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods and Operators
+
+
+        /// <summary>
+        /// The test ignore.
+        /// </summary>
+        /// <param name="message">
+        /// The message.
+        /// </param>
+        public void TestIgnore(string message)
+        {
+            this.TestInconclusive(message); // there is no dynamic "Ignore" in mstest
+        }
+
+        /// <summary>
+        /// The test inconclusive.
+        /// </summary>
+        /// <param name="message">
+        /// The message.
+        /// </param>
+        public void TestInconclusive(string message)
+        {
+            if (assertInconclusive == null)
+            {
+                assertInconclusive = UnitTestRuntimeProviderHelper.GetAssertMethodWithFormattedMessage(AssemblyName, ASSERT_TYPE, "Inconclusive");
+            }
+
+            assertInconclusive("{0}", new object[] { message });
+        }
+
+        /// <summary>
+        /// The test pending.
+        /// </summary>
+        /// <param name="message">
+        /// The message.
+        /// </param>
+        public void TestPending(string message)
+        {
+            this.TestInconclusive(message);
+        }
+
+        #endregion
+    }
+}

--- a/Generator/TechTalk.SpecFlow.Generator.csproj
+++ b/Generator/TechTalk.SpecFlow.Generator.csproj
@@ -109,6 +109,7 @@
     <Compile Include="TestGenerator.cs" />
     <Compile Include="TestGeneratorFactory.cs" />
     <Compile Include="UnitTestConverter\IFeatureGeneratorProvider.cs" />
+    <Compile Include="UnitTestProvider\MsTestWinRTGeneratorProvider.cs" />
     <Compile Include="UnitTestProvider\UnitTestGeneratorProviders.cs" />
     <Compile Include="UnitTestProvider\MbUnit3TestGeneratorProvider.cs" />
     <Compile Include="UnitTestProvider\MsTestSilverlightGeneratorProvider.cs" />

--- a/Generator/UnitTestFeatureGenerator.cs
+++ b/Generator/UnitTestFeatureGenerator.cs
@@ -194,14 +194,8 @@ namespace TechTalk.SpecFlow.Generator
             testGeneratorProvider.SetTestClassInitializeMethod(generationContext);
 
             //testRunner = TestRunnerManager.GetTestRunner();
-            var testRunnerField = GetTestRunnerExpression();
-            var methodName = generationContext.GenerateAsynchTests ? "GetAsyncTestRunner" : "GetTestRunner"; 
-            testClassInitializeMethod.Statements.Add(
-                new CodeAssignStatement(
-                    testRunnerField,
-                    new CodeMethodInvokeExpression(
-                        new CodeTypeReferenceExpression(typeof(TestRunnerManager)),
-                        methodName)));
+            CodeExpression testRunnerField = GetTestRunnerExpression();
+            testGeneratorProvider.SetTestRunner(generationContext, testRunnerField);
 
             //FeatureInfo featureInfo = new FeatureInfo("xxxx");
             testClassInitializeMethod.Statements.Add(

--- a/Generator/UnitTestProvider/IUnitTestGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/IUnitTestGeneratorProvider.cs
@@ -28,5 +28,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
         void SetRowTest(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string scenarioTitle);
         void SetRow(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, IEnumerable<string> arguments, IEnumerable<string> tags, bool isIgnored);
         void SetTestMethodAsRow(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string scenarioTitle, string exampleSetName, string variantName, IEnumerable<KeyValuePair<string, string>> arguments);
+
+        void SetTestRunner(TestClassGenerationContext generationContext, CodeExpression testRunnerField);
     }
 }

--- a/Generator/UnitTestProvider/MbUnitTestGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/MbUnitTestGeneratorProvider.cs
@@ -117,5 +117,16 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
         {
             // doing nothing since we support RowTest
         }
+
+        public void SetTestRunner(TestClassGenerationContext generationContext, CodeExpression testRunnerField)
+        {
+            var methodName = generationContext.GenerateAsynchTests ? "GetAsyncTestRunner" : "GetTestRunner";
+            generationContext.TestClassInitializeMethod.Statements.Add(
+                new CodeAssignStatement(
+                    testRunnerField,
+                    new CodeMethodInvokeExpression(
+                        new CodeTypeReferenceExpression(typeof(TestRunnerManager)),
+                        methodName)));
+        }
     }
 }

--- a/Generator/UnitTestProvider/MsTestGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/MsTestGeneratorProvider.cs
@@ -173,5 +173,16 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
                 SetProperty(testMethod, "Parameter:" + pair.Key, pair.Value);
             }
         }
+
+        public void SetTestRunner(TestClassGenerationContext generationContext, CodeExpression testRunnerField)
+        {
+            var methodName = generationContext.GenerateAsynchTests ? "GetAsyncTestRunner" : "GetTestRunner";
+            generationContext.TestClassInitializeMethod.Statements.Add(
+                new CodeAssignStatement(
+                    testRunnerField,
+                    new CodeMethodInvokeExpression(
+                        new CodeTypeReferenceExpression(typeof(TestRunnerManager)),
+                        methodName)));
+        }
     }
 }

--- a/Generator/UnitTestProvider/MsTestWinRTGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/MsTestWinRTGeneratorProvider.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.CodeDom;
+using System.Collections.Generic;
+using TechTalk.SpecFlow.Utils;
+
+namespace TechTalk.SpecFlow.Generator.UnitTestProvider
+{
+    public class MsTestWinRTGeneratorProvider : IUnitTestGeneratorProvider
+    {
+        protected const string TESTFIXTURE_ATTR = "Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute";
+        protected const string TEST_ATTR = "Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute";
+        protected const string PROPERTY_ATTR = "Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestPropertyAttribute";
+        protected const string TESTFIXTURESETUP_ATTR = "Microsoft.VisualStudio.TestPlatform.UnitTestFramework.ClassInitializeAttribute";
+        protected const string TESTFIXTURETEARDOWN_ATTR = "Microsoft.VisualStudio.TestPlatform.UnitTestFramework.ClassCleanupAttribute";
+        protected const string TESTSETUP_ATTR = "Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestInitializeAttribute";
+        protected const string TESTTEARDOWN_ATTR = "Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestCleanupAttribute";
+        protected const string IGNORE_ATTR = "Microsoft.VisualStudio.TestPlatform.UnitTestFramework.IgnoreAttribute";
+        protected const string DESCRIPTION_ATTR = "System.ComponentModel.DescriptionAttribute";
+
+        protected const string FEATURE_TITILE_PROPERTY_NAME = "FeatureTitle";
+
+        protected const string TESTCONTEXT_TYPE = "Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestContext";
+
+        protected CodeDomHelper CodeDomHelper { get; set; }
+
+        public virtual bool SupportsRowTests { get { return false; } }
+        public virtual bool SupportsAsyncTests { get { return false; } }
+
+        public MsTestWinRTGeneratorProvider(CodeDomHelper codeDomHelper)
+        {
+            CodeDomHelper = codeDomHelper;
+        }
+
+        private void SetProperty(CodeTypeMember codeTypeMember, string name, string value)
+        {
+            CodeDomHelper.AddAttribute(codeTypeMember, PROPERTY_ATTR, name, value);
+        }
+
+        public virtual void SetTestClass(TestClassGenerationContext generationContext, string featureTitle, string featureDescription)
+        {
+            CodeDomHelper.AddAttribute(generationContext.TestClass, TESTFIXTURE_ATTR);
+        }
+
+        public virtual void SetTestClassCategories(TestClassGenerationContext generationContext, IEnumerable<string> featureCategories)
+        {
+            //MsTest does not support caregories... :(
+        }
+
+        public void SetTestClassIgnore(TestClassGenerationContext generationContext)
+        {
+            CodeDomHelper.AddAttribute(generationContext.TestClass, IGNORE_ATTR);
+        }
+
+        public virtual void FinalizeTestClass(TestClassGenerationContext generationContext)
+        {
+            // by default, doing nothing to the final generated code
+        }
+
+
+        public virtual void SetTestClassInitializeMethod(TestClassGenerationContext generationContext)
+        {
+            generationContext.TestClassInitializeMethod.Attributes |= MemberAttributes.Static;
+            generationContext.TestClassInitializeMethod.Parameters.Add(new CodeParameterDeclarationExpression(
+                TESTCONTEXT_TYPE, "testContext"));
+
+            CodeDomHelper.AddAttribute(generationContext.TestClassInitializeMethod, TESTFIXTURESETUP_ATTR);
+        }
+
+        public void SetTestClassCleanupMethod(TestClassGenerationContext generationContext)
+        {
+            generationContext.TestClassCleanupMethod.Attributes |= MemberAttributes.Static;
+            CodeDomHelper.AddAttribute(generationContext.TestClassCleanupMethod, TESTFIXTURETEARDOWN_ATTR);
+        }
+
+
+        public virtual void SetTestInitializeMethod(TestClassGenerationContext generationContext)
+        {
+            CodeDomHelper.AddAttribute(generationContext.TestInitializeMethod, TESTSETUP_ATTR);
+
+            //if (FeatureContext.Current != null && FeatureContext.Current.FeatureInfo.Title != "<current_feature_title>")
+            //  <TestClass>.<TestClassInitialize>(null);
+
+            FixTestRunOrderingIssue(generationContext);
+        }
+
+        protected virtual void FixTestRunOrderingIssue(TestClassGenerationContext generationContext)
+        {
+            //see https://github.com/techtalk/SpecFlow/issues/96
+            generationContext.TestInitializeMethod.Statements.Add(
+                new CodeConditionStatement(
+                    new CodeBinaryOperatorExpression(
+                        new CodeBinaryOperatorExpression(
+                            new CodePropertyReferenceExpression(
+                                new CodeTypeReferenceExpression(typeof (FeatureContext)),
+                                "Current"),
+                            CodeBinaryOperatorType.IdentityInequality,
+                            new CodePrimitiveExpression(null)),
+                        CodeBinaryOperatorType.BooleanAnd,
+                        new CodeBinaryOperatorExpression(
+                            new CodePropertyReferenceExpression(
+                                new CodePropertyReferenceExpression(
+                                    new CodePropertyReferenceExpression(
+                                        new CodeTypeReferenceExpression(typeof (FeatureContext)),
+                                        "Current"),
+                                    "FeatureInfo"),
+                                "Title"),
+                            CodeBinaryOperatorType.IdentityInequality,
+                            new CodePrimitiveExpression(generationContext.Feature.Title))),
+                    new CodeExpressionStatement(
+                        new CodeMethodInvokeExpression(
+                            new CodeTypeReferenceExpression(
+                                generationContext.Namespace.Name + "." + generationContext.TestClass.Name
+                                ),
+                            generationContext.TestClassInitializeMethod.Name,
+                            new CodePrimitiveExpression(null)))));
+        }
+
+        public void SetTestCleanupMethod(TestClassGenerationContext generationContext)
+        {
+            CodeDomHelper.AddAttribute(generationContext.TestCleanupMethod, TESTTEARDOWN_ATTR);
+        }
+
+
+        public virtual void SetTestMethod(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string scenarioTitle)
+        {
+            CodeDomHelper.AddAttribute(testMethod, TEST_ATTR);
+            CodeDomHelper.AddAttribute(testMethod, DESCRIPTION_ATTR, scenarioTitle);
+
+            //as in mstest, you cannot mark classes with the description attribute, we
+            //just apply it for each test method as a property
+            SetProperty(testMethod, FEATURE_TITILE_PROPERTY_NAME, generationContext.Feature.Title);
+        }
+
+        public virtual void SetTestMethodCategories(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, IEnumerable<string> scenarioCategories)
+        {
+            //MsTest does not support caregories... :(
+        }
+
+        public void SetTestMethodIgnore(TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
+        {
+            CodeDomHelper.AddAttribute(testMethod, IGNORE_ATTR);
+        }
+
+
+        public virtual void SetRowTest(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string scenarioTitle)
+        {
+            //MsTest does not support row tests... :(
+            throw new NotSupportedException();
+        }
+
+        public virtual void SetRow(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, IEnumerable<string> arguments, IEnumerable<string> tags, bool isIgnored)
+        {
+            //MsTest does not support row tests... :(
+            throw new NotSupportedException();
+        }
+
+
+        public virtual void SetTestMethodAsRow(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string scenarioTitle, string exampleSetName, string variantName, IEnumerable<KeyValuePair<string, string>> arguments)
+        {
+            if (!string.IsNullOrEmpty(exampleSetName))
+            {
+                SetProperty(testMethod, "ExampleSetName", exampleSetName);
+            }
+
+            if (!string.IsNullOrEmpty(variantName))
+            {
+                SetProperty(testMethod, "VariantName", variantName);
+            }
+
+            foreach (var pair in arguments)
+            {
+                SetProperty(testMethod, "Parameter:" + pair.Key, pair.Value);
+            }
+        }
+
+        public void SetTestRunner(TestClassGenerationContext generationContext, CodeExpression testRunnerField)
+        {
+            // Add System.Reflection import - required for GetTypeInfo extension method
+            generationContext.Namespace.Imports.Add(new CodeNamespaceImport("System.Reflection"));
+            
+            generationContext.TestClassInitializeMethod.Statements.Add(new CodeVariableDeclarationStatement(typeof(System.Reflection.Assembly), "assembly"));
+
+            // typeof(ApplicationHasTestsFeature).GetType().GetTypeInfo().Assembly
+            var assemblyField = new CodeVariableReferenceExpression("assembly");
+
+            generationContext.TestClassInitializeMethod.Statements.Add(
+                new CodeAssignStatement(
+                    assemblyField,
+                    new CodePropertyReferenceExpression(new CodeMethodInvokeExpression(new CodeTypeOfExpression(new CodeTypeReference(generationContext.TestClass.Name)),"GetTypeInfo"),"Assembly")));
+
+            var methodName = generationContext.GenerateAsynchTests ? "GetAsyncTestRunner" : "GetTestRunner";
+            generationContext.TestClassInitializeMethod.Statements.Add(
+                new CodeAssignStatement(
+                    testRunnerField,
+                    new CodeMethodInvokeExpression(
+                        new CodeTypeReferenceExpression(typeof(TestRunnerManager)),
+                        methodName, assemblyField)));
+        }
+    }
+}

--- a/Generator/UnitTestProvider/NUnitTestGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/NUnitTestGeneratorProvider.cs
@@ -117,5 +117,16 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
         {
             // doing nothing since we support RowTest
         }
+
+        public void SetTestRunner(TestClassGenerationContext generationContext, CodeExpression testRunnerField)
+        {
+            var methodName = generationContext.GenerateAsynchTests ? "GetAsyncTestRunner" : "GetTestRunner";
+            generationContext.TestClassInitializeMethod.Statements.Add(
+                new CodeAssignStatement(
+                    testRunnerField,
+                    new CodeMethodInvokeExpression(
+                        new CodeTypeReferenceExpression(typeof(TestRunnerManager)),
+                        methodName)));
+        }
     }
 }

--- a/Generator/UnitTestProvider/UnitTestGeneratorProviders.cs
+++ b/Generator/UnitTestProvider/UnitTestGeneratorProviders.cs
@@ -18,6 +18,7 @@ namespace TechTalk.SpecFlow.Generator
             container.RegisterTypeAs<MsTestGeneratorProvider, IUnitTestGeneratorProvider>("mstest.2008");
             container.RegisterTypeAs<MsTest2010GeneratorProvider, IUnitTestGeneratorProvider>("mstest.2010");
             container.RegisterTypeAs<MsTest2010GeneratorProvider, IUnitTestGeneratorProvider>("mstest");
+            container.RegisterTypeAs<MsTestWinRTGeneratorProvider, IUnitTestGeneratorProvider>("mstest.winRT");
 
             container.RegisterTypeAs<MsTestSilverlightGeneratorProvider, IUnitTestGeneratorProvider>("mstest.silverlight");
             container.RegisterTypeAs<MsTestSilverlightGeneratorProvider, IUnitTestGeneratorProvider>("mstest.silverlight3");

--- a/Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
@@ -210,5 +210,16 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
         {
             // doing nothing since we support RowTest
         }
+
+        public void SetTestRunner(TestClassGenerationContext generationContext, CodeExpression testRunnerField)
+        {
+            var methodName = generationContext.GenerateAsynchTests ? "GetAsyncTestRunner" : "GetTestRunner";
+            generationContext.TestClassInitializeMethod.Statements.Add(
+                new CodeAssignStatement(
+                    testRunnerField,
+                    new CodeMethodInvokeExpression(
+                        new CodeTypeReferenceExpression(typeof(TestRunnerManager)),
+                        methodName)));
+        }
     }
 }

--- a/Runtime/Assist/EnumerableProjection.cs
+++ b/Runtime/Assist/EnumerableProjection.cs
@@ -5,6 +5,8 @@ using System.Text;
 
 namespace TechTalk.SpecFlow.Assist
 {
+    using System.Reflection;
+
     public class EnumerableProjection<T> : IEnumerable<Projection<T>>
     {
         private IEnumerable<T> collection;
@@ -143,8 +145,12 @@ namespace TechTalk.SpecFlow.Assist
         {
             foreach (var property in properties)
             {
+#if WINRT
+                if (t1.GetType().GetTypeInfo().GetDeclaredProperty(property) == null || t2.GetType().GetTypeInfo().GetDeclaredProperty(property) == null)
+#else
                 if (t1.GetType().GetProperty(property) == null || t2.GetType().GetProperty(property) == null)
-                    return false;
+#endif
+                return false;
 
                 var thisValue = t1.GetPropertyValue(property);
                 var otherValue = t2.GetPropertyValue(property);

--- a/Runtime/Assist/PropertyExtensionMethods.cs
+++ b/Runtime/Assist/PropertyExtensionMethods.cs
@@ -3,6 +3,8 @@ using System.Reflection;
 
 namespace TechTalk.SpecFlow.Assist
 {
+    using System;
+
     internal static class PropertyExtensionMethods
     {
         public static object GetPropertyValue(this object @object, string propertyName)

--- a/Runtime/Assist/RowExtensionMethods.cs
+++ b/Runtime/Assist/RowExtensionMethods.cs
@@ -92,11 +92,19 @@ namespace TechTalk.SpecFlow.Assist
 
         private static Type GetTheEnumType<T>(string propertyName, string value)
         {
+#if WINRT
+            var propertyType = (from property in typeof (T).GetProperties()
+                                where property.Name == propertyName
+                                      && property.PropertyType.GetTypeInfo().IsEnum
+                                      && EnumValueIsDefinedCaseInsensitve(property.PropertyType, value)
+                                select property.PropertyType).FirstOrDefault();
+#else
             var propertyType = (from property in typeof (T).GetProperties()
                                 where property.Name == propertyName
                                       && property.PropertyType.IsEnum
                                       && EnumValueIsDefinedCaseInsensitve(property.PropertyType, value)
                                 select property.PropertyType).FirstOrDefault();
+#endif
 
             if (propertyType == null)
                 throw new InvalidOperationException(string.Format("No enum with value {0} found in type {1}", value, typeof(T).Name));

--- a/Runtime/Assist/TEHelpers.cs
+++ b/Runtime/Assist/TEHelpers.cs
@@ -93,8 +93,12 @@ namespace TechTalk.SpecFlow.Assist
         {
             if (key.IsAssignableFrom(property.PropertyType))
                 return true;
+#if WINRT
+            if (property.PropertyType.GetTypeInfo().IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+#else
             if (property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
-                return key.IsAssignableFrom(property.PropertyType.GetGenericArguments()[0]);
+#endif
+            return key.IsAssignableFrom(property.PropertyType.GetGenericArguments()[0]);
             return false;
         }
 

--- a/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
@@ -2,6 +2,8 @@
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
+    using System.Reflection;
+
     internal class EnumValueRetriever
     {
         public object GetValue(string value, Type enumType)
@@ -46,7 +48,11 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 
         private static bool ThisIsNotANullableEnum(Type enumType)
         {
+#if WINRT
+            return enumType.GetTypeInfo().IsGenericType == false;
+#else
             return enumType.IsGenericType == false;
+#endif
         }
 
         private string ParseTheValue(string value)

--- a/Runtime/BindingSkeletons/DefaultSkeletonTemplateProvider.cs
+++ b/Runtime/BindingSkeletons/DefaultSkeletonTemplateProvider.cs
@@ -4,11 +4,17 @@ using System.Linq;
 
 namespace TechTalk.SpecFlow.BindingSkeletons
 {
+    using System.Reflection;
+
     public class ResourceSkeletonTemplateProvider : FileBasedSkeletonTemplateProvider
     {
         protected override string GetTemplateFileContent()
         {
+#if WINRT
+            var resourceStream = GetType().GetTypeInfo().Assembly.GetManifestResourceStream("TechTalk.Specflow.WindowsStore.SharedRuntime.DefaultSkeletonTemplates.sftemplate");
+#else
             var resourceStream = GetType().Assembly.GetManifestResourceStream(GetType(), "DefaultSkeletonTemplates.sftemplate");
+#endif
             if (resourceStream == null)
                 throw new SpecFlowException("Missing resource: DefaultSkeletonTemplates.sftemplate");
 
@@ -28,7 +34,7 @@ namespace TechTalk.SpecFlow.BindingSkeletons
 
         protected override string GetTemplateFileContent()
         {
-#if SILVERLIGHT
+#if SILVERLIGHT || WINRT
             return "";
 #else
             string templateFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"SpecFlow\SkeletonTemplates.sftemplate");

--- a/Runtime/BindingSkeletons/StepDefinitionSkeletonProvider.cs
+++ b/Runtime/BindingSkeletons/StepDefinitionSkeletonProvider.cs
@@ -102,7 +102,11 @@ namespace TechTalk.SpecFlow.BindingSkeletons
             appendWords(analyzedStepText.TextParts[0], language, result);
             for (int i = 1; i < analyzedStepText.TextParts.Count; i++)
             {
+#if WINRT
+                result.AppendFormat(paramFormat, analyzedStepText.Parameters[i - 1].Name.ToUpper());
+#else
                 result.AppendFormat(paramFormat, analyzedStepText.Parameters[i - 1].Name.ToUpper(CultureInfo.InvariantCulture));
+#endif
                 appendWords(analyzedStepText.TextParts[i], language, result);
             }
 
@@ -125,7 +129,11 @@ namespace TechTalk.SpecFlow.BindingSkeletons
         {
             foreach (var word in GetWords(text))
             {
+#if WINRT
+                result.Append(word.Substring(0, 1).ToUpper());
+#else
                 result.Append(word.Substring(0, 1).ToUpper(language));
+#endif
                 result.Append(word.Substring(1));
             }
         }

--- a/Runtime/Bindings/BindingInvoker.cs
+++ b/Runtime/Bindings/BindingInvoker.cs
@@ -118,6 +118,22 @@ namespace TechTalk.SpecFlow.Bindings
                 var scenarioContextProperty = ExpressionMemberAccessor.GetPropertyInfo((IContextManager cm) => cm.ScenarioContext);
                 Debug.Assert(scenarioContextProperty != null, "ScenarioContext not found");
 
+#if WINRT 
+                lambda = Expression.Lambda(
+                    delegateType,
+                    Expression.Call(
+                        Expression.Convert(
+                            Expression.Call(
+                                Expression.Property(
+                                    contextManagerArg,
+                                    scenarioContextProperty),
+                                getInstanceMethod,
+                                Expression.Constant(method.DeclaringType, typeof(Type))),
+                            method.DeclaringType),
+                        method,
+                        methodArguments),
+                    parameters.ToArray());
+#else
                 lambda = Expression.Lambda(
                     delegateType,
                     Expression.Call(
@@ -132,6 +148,7 @@ namespace TechTalk.SpecFlow.Bindings
                         method, 
                         methodArguments),
                     parameters.ToArray());
+#endif
             }
 
 #if WINDOWS_PHONE

--- a/Runtime/Bindings/Discovery/BindingSourceProcessor.cs
+++ b/Runtime/Bindings/Discovery/BindingSourceProcessor.cs
@@ -32,7 +32,11 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
 
         public static bool IsPotentialBindingClass(IEnumerable<string> attributeTypeNames)
         {
+#if WINRT
+            return attributeTypeNames.Any(attr => attr.Equals(BINDING_ATTR, StringComparison.Ordinal));
+#else
             return attributeTypeNames.Any(attr => attr.Equals(BINDING_ATTR, StringComparison.InvariantCulture));
+#endif
         }
 
         public bool PreFilterType(IEnumerable<string> attributeTypeNames)

--- a/Runtime/Bindings/Discovery/RuntimeBindingRegistryBuilder.cs
+++ b/Runtime/Bindings/Discovery/RuntimeBindingRegistryBuilder.cs
@@ -38,7 +38,11 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
             if (!bindingSourceProcessor.ProcessType(bindingSourceType))
                 return false;
 
+#if WINRT
+            foreach (var methodInfo in type.GetTypeInfo().DeclaredMethods)
+#else
             foreach (var methodInfo in type.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+#endif
             {
                 bindingSourceProcessor.ProcessMethod(CreateBindingSourceMethod(methodInfo));
             }
@@ -66,6 +70,19 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
 
         private BindingSourceType CreateBindingSourceType(Type type, IEnumerable<Attribute> filteredAttributes)
         {
+#if WINRT
+            var typeInfo = type.GetTypeInfo();
+            return new BindingSourceType
+            {
+                BindingType = CreateBindingType(type),
+                IsAbstract = typeInfo.IsAbstract,
+                IsClass = typeInfo.IsClass,
+                IsPublic = typeInfo.IsPublic,
+                IsNested = TypeHelper.IsNested(type),
+                IsGenericTypeDefinition = typeInfo.IsGenericTypeDefinition,
+                Attributes = GetAttributes(filteredAttributes)
+            };
+#else
             return new BindingSourceType
                        {
                            BindingType = CreateBindingType(type),
@@ -76,10 +93,25 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
                            IsGenericTypeDefinition = type.IsGenericTypeDefinition,
                            Attributes = GetAttributes(filteredAttributes)
                        };
+#endif
         }
 
         private BindingSourceAttribute CreateAttribute(Attribute attribute)
         {
+#if WINRT
+            var attributeType = attribute.GetType();
+            var namedAttributeValues = attributeType.GetTypeInfo().DeclaredFields.Where(f => !f.IsStatic && f.IsPublic).Where(
+                f => !f.IsSpecialName).Select(
+                    f => new { f.Name, Value = new BindingSourceAttributeValueProvider(f.GetValue(attribute)) })
+                .Concat(
+                    attributeType.GetTypeInfo().DeclaredProperties.Where(p => !p.GetMethod.IsStatic && p.GetMethod.IsPublic).Where(
+                        p => !p.IsSpecialName && p.CanRead && p.GetIndexParameters().Length == 0).Select(
+                            p =>
+                            new { p.Name, Value = new BindingSourceAttributeValueProvider(p.GetValue(attribute, null)) })
+                ).ToDictionary(na => na.Name, na => (IBindingSourceAttributeValueProvider)na.Value);
+
+            var mostComplexCtor = attributeType.GetTypeInfo().DeclaredConstructors.Where(c => !c.IsStatic && c.IsPublic).OrderByDescending(ctor => ctor.GetParameters().Length).FirstOrDefault();
+#else
             var attributeType = attribute.GetType();
             var namedAttributeValues = attributeType.GetFields(BindingFlags.Instance | BindingFlags.Public).Where(
                 f => !f.IsSpecialName).Select(
@@ -92,6 +124,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
                 ).ToDictionary(na => na.Name, na => (IBindingSourceAttributeValueProvider)na.Value);
 
             var mostComplexCtor = attributeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public).OrderByDescending(ctor => ctor.GetParameters().Length).FirstOrDefault();
+#endif
 
             return new BindingSourceAttribute
                        {

--- a/Runtime/Bindings/Reflection/BindingReflectionExtensions.cs
+++ b/Runtime/Bindings/Reflection/BindingReflectionExtensions.cs
@@ -20,9 +20,13 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
             if (type.FullName == baseType.FullName)
                 return true;
 
+#if WINRT
+            if (type.GetTypeInfo().BaseType != null && IsAssignableTo(baseType, type.GetTypeInfo().BaseType))
+                return true;
+#else
             if (type.BaseType != null && IsAssignableTo(baseType, type.BaseType))
                 return true;
-
+#endif
             return type.GetInterfaces().Any(_if => IsAssignableTo(baseType, _if));
         }
 

--- a/Runtime/Bindings/RegexFactory.cs
+++ b/Runtime/Bindings/RegexFactory.cs
@@ -4,7 +4,7 @@ namespace TechTalk.SpecFlow.Bindings
 {
     internal static class RegexFactory
     {
-#if SILVERLIGHT
+#if SILVERLIGHT || WINRT
         private static RegexOptions RegexOptions = RegexOptions.CultureInvariant;
 #else
         private static RegexOptions RegexOptions = RegexOptions.Compiled | RegexOptions.CultureInvariant;

--- a/Runtime/Bindings/StepArgumentTypeConverter.cs
+++ b/Runtime/Bindings/StepArgumentTypeConverter.cs
@@ -9,6 +9,8 @@ using TechTalk.SpecFlow.Tracing;
 
 namespace TechTalk.SpecFlow.Bindings
 {
+    using System.Reflection;
+
     public interface IStepArgumentTypeConverter
     {
         object Convert(object value, IBindingType typeToConvertTo, CultureInfo cultureInfo);
@@ -111,8 +113,12 @@ namespace TechTalk.SpecFlow.Bindings
 
         private static object ConvertSimple(Type typeToConvertTo, object value, CultureInfo cultureInfo)
         {
+#if WINRT
+            if (typeToConvertTo.GetTypeInfo().IsEnum && value is string)
+#else
             if (typeToConvertTo.IsEnum && value is string)
-                return Enum.Parse(typeToConvertTo, (string)value, true);
+#endif
+            return Enum.Parse(typeToConvertTo, (string)value, true);
 
             if (typeToConvertTo == typeof(Guid?) && string.IsNullOrEmpty(value as string))
                 return null;

--- a/Runtime/Configuration/ConfigurationServices.cs
+++ b/Runtime/Configuration/ConfigurationServices.cs
@@ -4,12 +4,19 @@ using TechTalk.SpecFlow.Infrastructure;
 
 namespace TechTalk.SpecFlow.Configuration
 {
+    using System.Linq;
+    using System.Reflection;
+
     public static class ConfigurationServices
     {
         public static TInterface CreateInstance<TInterface>(Type type)
         {
             //HACK: to provide backwards compatibility, until DI is fully introduced
+#if WINRT
+            if (type.GetPublicInstanceConstructors().FirstOrDefault(c => !c.GetParameters().Any()) == null)
+#else
             if (type.GetConstructor(new Type[0]) == null)
+#endif
             {
                 var container = TestRunContainerBuilder.CreateContainer();
                 return container.Resolve<TInterface>();

--- a/Runtime/CultureInfoScope.cs
+++ b/Runtime/CultureInfoScope.cs
@@ -11,6 +11,7 @@ namespace TechTalk.SpecFlow
 
         public CultureInfoScope(CultureInfo cultureInfo)
         {
+#if !WINRT
             if (cultureInfo != null && !cultureInfo.Equals(Thread.CurrentThread.CurrentCulture))
             {
                 if (cultureInfo.IsNeutralCulture)
@@ -20,12 +21,15 @@ namespace TechTalk.SpecFlow
                 originalCultureInfo = Thread.CurrentThread.CurrentCulture;
                 Thread.CurrentThread.CurrentCulture = cultureInfo;
             }
+#endif
         }
 
         public void Dispose()
         {
+#if !WINRT
             if (originalCultureInfo != null)
                 Thread.CurrentThread.CurrentCulture = originalCultureInfo;
+#endif
         }
     }
 }

--- a/Runtime/ErrorHandling/BindingException.cs
+++ b/Runtime/ErrorHandling/BindingException.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 // the exceptions are part of the public API, keep them in TechTalk.SpecFlow namespace
 namespace TechTalk.SpecFlow
 {
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !WINRT
     [Serializable]
 #endif
 
@@ -23,7 +23,7 @@ namespace TechTalk.SpecFlow
         {
         }
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !WINRT
         protected BindingException(
             SerializationInfo info,
             StreamingContext context) : base(info, context)

--- a/Runtime/ErrorHandling/MissingStepDefinitionException.cs
+++ b/Runtime/ErrorHandling/MissingStepDefinitionException.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 // the exceptions are part of the public API, keep them in TechTalk.SpecFlow namespace
 namespace TechTalk.SpecFlow
 {
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !WINRT
     [Serializable]
 #endif
     public class MissingStepDefinitionException : SpecFlowException
@@ -15,7 +15,7 @@ namespace TechTalk.SpecFlow
         {
         }
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !WINRT
         protected MissingStepDefinitionException(
             SerializationInfo info,
             StreamingContext context)

--- a/Runtime/ErrorHandling/PendingStepException.cs
+++ b/Runtime/ErrorHandling/PendingStepException.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 // the exceptions are part of the public API, keep them in TechTalk.SpecFlow namespace
 namespace TechTalk.SpecFlow
 {
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !WINRT
     [Serializable]
 #endif
     public class PendingStepException : SpecFlowException
@@ -15,7 +15,7 @@ namespace TechTalk.SpecFlow
         {
         }
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !WINRT
         protected PendingStepException(
             SerializationInfo info,
             StreamingContext context) : base(info, context)

--- a/Runtime/ErrorHandling/SpecFlowException.cs
+++ b/Runtime/ErrorHandling/SpecFlowException.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 // the exceptions are part of the public API, keep them in TechTalk.SpecFlow namespace
 namespace TechTalk.SpecFlow
 {
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !WINRT
     [Serializable]
 #endif
     public class SpecFlowException : Exception
@@ -22,7 +22,7 @@ namespace TechTalk.SpecFlow
         {
         }
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !WINRT
         protected SpecFlowException(
             SerializationInfo info,
             StreamingContext context) : base(info, context)

--- a/Runtime/Infrastructure/IBindingAssemblyLoader.cs
+++ b/Runtime/Infrastructure/IBindingAssemblyLoader.cs
@@ -11,7 +11,11 @@ namespace TechTalk.SpecFlow.Infrastructure
     {
         public Assembly Load(string assemblyName)
         {
+#if WINRT
+            return Assembly.Load(new AssemblyName(assemblyName));
+#else
             return Assembly.Load(assemblyName);
+#endif
         }
     }
 }

--- a/Runtime/Infrastructure/IRuntimePluginLoader.cs
+++ b/Runtime/Infrastructure/IRuntimePluginLoader.cs
@@ -18,14 +18,22 @@ namespace TechTalk.SpecFlow.Infrastructure
             Assembly assembly;
             try
             {
+#if WINRT
+                assembly = Assembly.Load(new AssemblyName(assemblyName));
+#else
                 assembly = Assembly.Load(assemblyName);
+#endif
             }
             catch(Exception ex)
             {
                 throw new SpecFlowException(string.Format("Unable to load plugin: {0}. Please check http://go.specflow.org/doc-plugins for details.", pluginDescriptor.Name), ex);
             }
 
+#if WINRT
+            var pluginAttribute = assembly.GetCustomAttribute<RuntimePluginAttribute>();
+#else
             var pluginAttribute = (RuntimePluginAttribute)Attribute.GetCustomAttribute(assembly, typeof(RuntimePluginAttribute));
+#endif
             if (pluginAttribute == null)
                 throw new SpecFlowException(string.Format("Missing [assembly:RuntimePlugin] attribute in {0}. Please check http://go.specflow.org/doc-plugins for details.", assembly.FullName));
 

--- a/Runtime/Infrastructure/TestExecutionEngine.cs
+++ b/Runtime/Infrastructure/TestExecutionEngine.cs
@@ -74,7 +74,7 @@ namespace TechTalk.SpecFlow.Infrastructure
             bindingRegistry.Ready = true;
 
             OnTestRunnerStart();
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !WINRT
             AppDomain.CurrentDomain.DomainUnload += 
                 delegate
                     {

--- a/Runtime/TestRunnerManager.cs
+++ b/Runtime/TestRunnerManager.cs
@@ -105,6 +105,12 @@ namespace TechTalk.SpecFlow
 
         #region Static Methods
 
+#if WINRT
+        public static ITestRunner GetTestRunner(Assembly testAssembly)
+        {
+            return Instance.GetTestRunner(testAssembly, false);
+        }
+#else
         public static ITestRunner GetTestRunner()
         {
             return Instance.GetTestRunner(Assembly.GetCallingAssembly(), false);
@@ -114,6 +120,7 @@ namespace TechTalk.SpecFlow
         {
             return Instance.GetTestRunner(Assembly.GetCallingAssembly(), true);
         }
+#endif
 
         internal static void Reset()
         {

--- a/Runtime/Tracing/LanguageHelper.cs
+++ b/Runtime/Tracing/LanguageHelper.cs
@@ -11,6 +11,8 @@ using TechTalk.SpecFlow.Compatibility;
 
 namespace TechTalk.SpecFlow.Tracing
 {
+    using System.Reflection;
+
     internal static class LanguageHelper
     {
         struct KeywordSet
@@ -79,8 +81,13 @@ namespace TechTalk.SpecFlow.Tracing
 
         private static KeywordTranslation LoadTranslation(CultureInfo language)
         {
+#if WINRT
+            var assembly = typeof(LanguageHelper).GetTypeInfo().Assembly;
+            var docStream = assembly.GetManifestResourceStream("TechTalk.Specflow.WindowsStore.Languages.xml");
+#else
             var assembly = typeof(LanguageHelper).Assembly;
             var docStream = assembly.GetManifestResourceStream("TechTalk.SpecFlow.Languages.xml");
+#endif
             if (docStream == null)
                 throw new InvalidOperationException("Language resource not found.");
 

--- a/Runtime/UnitTestProvider/UnitTestRuntimeProviderHelper.cs
+++ b/Runtime/UnitTestProvider/UnitTestRuntimeProviderHelper.cs
@@ -10,12 +10,22 @@ namespace TechTalk.SpecFlow.UnitTestProvider
     {
         public static Action<string, object[]> GetAssertMethodWithFormattedMessage(string assemblyName, string typeName, string methodName)
         {
+#if WINRT
+            Assembly msTestAssembly = Assembly.Load(new AssemblyName(assemblyName));
+            Type assertType = msTestAssembly.GetType(typeName);
+
+            MethodInfo method =
+                assertType.GetTypeInfo().DeclaredMethods.FirstOrDefault(
+                    m => m.IsPublic && m.IsStatic && m.GetParameters().Count() == 2 && m.GetParameters()[0].ParameterType == typeof(string) && m.GetParameters()[1].ParameterType == typeof(object[]));
+#else
             Assembly msTestAssembly = Assembly.Load(assemblyName);
             Type assertType = msTestAssembly.GetType(typeName, true);
 
             MethodInfo method = assertType.GetMethod(methodName,
                                                      BindingFlags.Public | BindingFlags.Static, null,
                                                      new Type[] { typeof(string), typeof(object[]) }, null);
+#endif
+
             if (method == null)
                 throw new SpecFlowException("Assert method not found: " + methodName);
 

--- a/TechTalk.SpecFlow-VS2012.sln
+++ b/TechTalk.SpecFlow-VS2012.sln
@@ -1,0 +1,70 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{577A0375-1436-446C-802B-3C75C8CEF94F}"
+	ProjectSection(SolutionItems) = preProject
+		changelog.txt = changelog.txt
+		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
+		LICENSE.txt = LICENSE.txt
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AlternativeRuntimes", "AlternativeRuntimes", "{01A98306-2E7F-42E5-A180-C31C4DC82C57}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{8C4BDE8C-3363-4575-AAA4-E6D7AAA51C5B}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\nuget.exe = .nuget\nuget.exe
+		.nuget\NuGet.targets = .nuget\NuGet.targets
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TechTalk.Specflow.WindowsStore", "AlternativeRuntimes\Runtime.WindowsStore\TechTalk.Specflow.WindowsStore.csproj", "{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM = Debug|ARM
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|ARM = Release|ARM
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		VS2010IntegrationTest|Any CPU = VS2010IntegrationTest|Any CPU
+		VS2010IntegrationTest|ARM = VS2010IntegrationTest|ARM
+		VS2010IntegrationTest|x64 = VS2010IntegrationTest|x64
+		VS2010IntegrationTest|x86 = VS2010IntegrationTest|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Debug|ARM.ActiveCfg = Debug|ARM
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Debug|ARM.Build.0 = Debug|ARM
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Debug|x64.ActiveCfg = Debug|x64
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Debug|x64.Build.0 = Debug|x64
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Debug|x86.ActiveCfg = Debug|x86
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Debug|x86.Build.0 = Debug|x86
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Release|ARM.ActiveCfg = Release|ARM
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Release|ARM.Build.0 = Release|ARM
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Release|x64.ActiveCfg = Release|x64
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Release|x64.Build.0 = Release|x64
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Release|x86.ActiveCfg = Release|x86
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.Release|x86.Build.0 = Release|x86
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.VS2010IntegrationTest|Any CPU.ActiveCfg = Release|Any CPU
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.VS2010IntegrationTest|Any CPU.Build.0 = Release|Any CPU
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.VS2010IntegrationTest|ARM.ActiveCfg = Release|ARM
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.VS2010IntegrationTest|ARM.Build.0 = Release|ARM
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.VS2010IntegrationTest|x64.ActiveCfg = Release|x64
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.VS2010IntegrationTest|x64.Build.0 = Release|x64
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.VS2010IntegrationTest|x86.ActiveCfg = Release|x86
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73}.VS2010IntegrationTest|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B8BE3373-0DF6-43C6-B89E-8AAD534A8F73} = {01A98306-2E7F-42E5-A180-C31C4DC82C57}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Added Windows Store runtime and associated changes to relevant shared runtime classes.
Added new VS2012 solution for the Windows Store runtime (can't add it to VS2010 project as project type isn't supported).
TODO: integrate windows store runtime into installer (not sure how at the moment as the VS2010 project can't build it).
