### PR TITLE
Updated to use GetRuntimeProperties/fields/methods instead of GetTypeInf...

### DIFF
--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/EnumHelper.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformCompatibility/EnumHelper.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Compatibility
 
             var values = new List<object>();
 
-            var fields = from field in enumType.GetTypeInfo().DeclaredFields
+            var fields = from field in enumType.GetRuntimeFields()
                          where field.IsLiteral
                          select field;
 
@@ -37,7 +37,7 @@ namespace TechTalk.SpecFlow.Compatibility
                 throw new ArgumentException("Type '" + enumType.Name + "' is not an enum");
             }
 
-            var fiArray = enumType.GetTypeInfo().DeclaredFields.Where(f => f.IsPublic && f.IsStatic);
+            var fiArray = enumType.GetRuntimeFields().Where(f => f.IsPublic && f.IsStatic);
             return fiArray.Select(fi => fi.Name).ToArray();
         }
     }

--- a/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/TypeExtensions.cs
+++ b/AlternativeRuntimes/Runtime.WindowsStore/PlatformSpecific/TypeExtensions.cs
@@ -14,7 +14,7 @@ namespace System
 
         public static IEnumerable<PropertyInfo> GetProperties(this Type self)
         {
-            return self.GetTypeInfo().DeclaredProperties;
+            return self.GetRuntimeProperties();
         }
 
         public static IEnumerable<ConstructorInfo> GetConstructors(this Type self)

--- a/Runtime/Assist/EnumerableProjection.cs
+++ b/Runtime/Assist/EnumerableProjection.cs
@@ -146,7 +146,7 @@ namespace TechTalk.SpecFlow.Assist
             foreach (var property in properties)
             {
 #if WINRT
-                if (t1.GetType().GetTypeInfo().GetDeclaredProperty(property) == null || t2.GetType().GetTypeInfo().GetDeclaredProperty(property) == null)
+                if (t1.GetType().GetRuntimeProperty(property) == null || t2.GetType().GetTypeInfo().GetDeclaredProperty(property) == null)
 #else
                 if (t1.GetType().GetProperty(property) == null || t2.GetType().GetProperty(property) == null)
 #endif

--- a/Runtime/Bindings/Discovery/RuntimeBindingRegistryBuilder.cs
+++ b/Runtime/Bindings/Discovery/RuntimeBindingRegistryBuilder.cs
@@ -39,7 +39,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
                 return false;
 
 #if WINRT
-            foreach (var methodInfo in type.GetTypeInfo().DeclaredMethods)
+            foreach (var methodInfo in type.GetRuntimeMethods().Where(m => m.DeclaringType != typeof(object)))
 #else
             foreach (var methodInfo in type.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
 #endif
@@ -100,11 +100,11 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
         {
 #if WINRT
             var attributeType = attribute.GetType();
-            var namedAttributeValues = attributeType.GetTypeInfo().DeclaredFields.Where(f => !f.IsStatic && f.IsPublic).Where(
+            var namedAttributeValues = attributeType.GetRuntimeFields().Where(f => !f.IsStatic && f.IsPublic).Where(
                 f => !f.IsSpecialName).Select(
                     f => new { f.Name, Value = new BindingSourceAttributeValueProvider(f.GetValue(attribute)) })
                 .Concat(
-                    attributeType.GetTypeInfo().DeclaredProperties.Where(p => !p.GetMethod.IsStatic && p.GetMethod.IsPublic).Where(
+                    attributeType.GetRuntimeProperties().Where(p => !p.GetMethod.IsStatic && p.GetMethod.IsPublic && p.DeclaringType != typeof(Attribute)).Where(
                         p => !p.IsSpecialName && p.CanRead && p.GetIndexParameters().Length == 0).Select(
                             p =>
                             new { p.Name, Value = new BindingSourceAttributeValueProvider(p.GetValue(attribute, null)) })

--- a/Runtime/UnitTestProvider/UnitTestRuntimeProviderHelper.cs
+++ b/Runtime/UnitTestProvider/UnitTestRuntimeProviderHelper.cs
@@ -15,7 +15,7 @@ namespace TechTalk.SpecFlow.UnitTestProvider
             Type assertType = msTestAssembly.GetType(typeName);
 
             MethodInfo method =
-                assertType.GetTypeInfo().DeclaredMethods.FirstOrDefault(
+                assertType.GetRuntimeMethods().FirstOrDefault(
                     m => m.IsPublic && m.IsStatic && m.GetParameters().Count() == 2 && m.GetParameters()[0].ParameterType == typeof(string) && m.GetParameters()[1].ParameterType == typeof(object[]));
 #else
             Assembly msTestAssembly = Assembly.Load(assemblyName);


### PR DESCRIPTION
...o().DeclaredProperties/fields/methods to get properties/fields/methods in base classes
